### PR TITLE
Create backend API for beercount with POST and GET at api/beer

### DIFF
--- a/models/schema.js
+++ b/models/schema.js
@@ -6,6 +6,7 @@ delete mongoose.connection.models["StreamLink"];
 delete mongoose.connection.models["SlidoView"];
 delete mongoose.connection.models["StretchGoal"];
 delete mongoose.connection.models["Bid"];
+delete mongoose.connection.models["BeerCount"];
 
 const AuctionSchema = new mongoose.Schema(
   {
@@ -60,3 +61,12 @@ const BidSchema = new mongoose.Schema(
   { autoCreate: true, timestamps: true }
 );
 export const Bid = mongoose.model("Bid", BidSchema);
+
+const BeerCountSchema = new mongoose.Schema(
+  {
+    count: { type: Number, default: 0 },
+  },
+  { autoCreate: true }
+);
+
+export const BeerCount = mongoose.model("BeerCount", BeerCountSchema);

--- a/pages/api/beer.js
+++ b/pages/api/beer.js
@@ -1,0 +1,38 @@
+import mongoose from "mongoose";
+
+import { BeerCount } from "../../models/schema.js";
+import { url } from "./state";
+
+export default async function handler(req, res) {
+  const { method, headers } = req;
+
+  mongoose.connect(url);
+
+  switch (method) {
+    case "POST": {
+      if (headers.password !== process.env.POST_PASSWORD) {
+        res.status(401).end();
+        return;
+      }
+
+      await BeerCount.findOneAndUpdate({}, { count: req.body.count });
+
+      res.status(200).json(await BeerCount.findOne({}));
+    }
+
+    case "GET":
+      {
+        const beerCount = await BeerCount.findOne({});
+        res.end(
+          JSON.stringify({
+            beerCount,
+          })
+        );
+      }
+
+      break;
+    default:
+      res.setHeader("Allow", ["GET", "POST"]);
+      res.status(405).end(`Method ${method} Not Allowed`);
+  }
+}

--- a/pages/api/state.js
+++ b/pages/api/state.js
@@ -7,6 +7,7 @@ import {
   SlidoView,
   StretchGoal,
   Bid,
+  BeerCount,
 } from "../../models/schema.js";
 
 const username = process.env.DATABASE_USER;
@@ -60,15 +61,23 @@ export default async function handler(_, res) {
   mongoose.connect(url);
 
   // Get all the state we need for the page
-  const [vipps, streamLink, slidoView, stretchGoals, topDonor, auctions] =
-    await Promise.all([
-      Vipps.find({}),
-      StreamLink.findOne().sort({ date: -1 }).limit(1),
-      SlidoView.findOne().sort({ date: -1 }).limit(1),
-      StretchGoal.find({}).sort("goal"),
-      Vipps.findOne({}).sort({ amount: -1 }).limit(1),
-      getHighestBids(),
-    ]);
+  const [
+    vipps,
+    streamLink,
+    slidoView,
+    stretchGoals,
+    topDonor,
+    auctions,
+    beerCount,
+  ] = await Promise.all([
+    Vipps.find({}),
+    StreamLink.findOne().sort({ date: -1 }).limit(1),
+    SlidoView.findOne().sort({ date: -1 }).limit(1),
+    StretchGoal.find({}).sort("goal"),
+    Vipps.findOne({}).sort({ amount: -1 }).limit(1),
+    getHighestBids(),
+    BeerCount.findOne({}),
+  ]);
 
   res.statusCode = 200;
   res.setHeader("Content-Type", "application/json");
@@ -87,6 +96,7 @@ export default async function handler(_, res) {
       slidoView,
       stretchGoals,
       topDonor,
+      beerCount,
     })
   );
 }


### PR DESCRIPTION
The api is available at `/api/beer`

POST-ing to the API will update/overwrite the current beercount
POST api expects these:
* raw JSON in body looking like:
```
{  "count" : 42 }
```
* post-password under the "password" header
\.

Simiarily, the GET request response will look something like: 
```
{"beerCount":{"_id":"615774b5f2620b6a324f9ec4","count":42}}
```