### PR TITLE
Make prettier and eslint only check in CI

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -27,7 +27,7 @@ steps:
     depends_on:
       - setup
     commands:
-      - yarn prettier
+      - yarn ci-prettier
 
   - name: lint
     image: node:14-alpine
@@ -36,4 +36,4 @@ steps:
     depends_on:
       - setup
     commands:
-      - yarn lint
+      - yarn ci-lint

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ $ yarn dev # Run dev server
 ```
 
 This project uses `prettier` and `eslint`.
+
 ```sh
 $ yarn lint # Check linting
 $ yarn prettier # Format all files with prettier

--- a/components/StretchGoals.js
+++ b/components/StretchGoals.js
@@ -13,7 +13,7 @@ export default function StretchGoals(props) {
     .filter((goal) => goal.goal <= totalAmount)
     .reverse();
   if (stretchGoals.length === 0) {
-    return <p className="text-center">Ingen stretch goals er satt!</p>
+    return <p className="text-center">Ingen stretch goals er satt!</p>;
   }
   return (
     <div className="flex flex-wrap items-center h-full p-2 overflow-hidden justify-evenly">

--- a/components/Vipps.js
+++ b/components/Vipps.js
@@ -45,7 +45,11 @@ const Vipps = (props) => {
       <TopVipp vipp={props.topDonor} />
       <hr />
       {vipps}
-      {props.items.length === 0 && (<p className="text-center">Ingen Vipps-donasjoner er registrert enda! :(</p>)}
+      {props.items.length === 0 && (
+        <p className="text-center">
+          Ingen Vipps-donasjoner er registrert enda! :(
+        </p>
+      )}
     </div>
   );
 };

--- a/package.json
+++ b/package.json
@@ -6,7 +6,9 @@
     "build": "next build",
     "start": "next start",
     "lint": "next lint --fix",
-    "prettier": "prettier '**/*.{js,css,md}' --write"
+    "prettier": "prettier '**/*.{js,css,md}' --write",
+    "ci-lint": "next lint",
+    "ci-prettier": "prettier '**/*.{js,css,md}' --check"
   },
   "dependencies": {
     "classnames": "^2.3.1",


### PR DESCRIPTION
Previously, prettier and ESLint "applied"
their fixes in CI, which resulted in it
accepting badly formatted code.

Now, it checks instead of write when running in CI,
making it actually do its job.