### PR TITLE
extend containers to screen width

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -74,7 +74,7 @@ export default function Page() {
       </header>
 
       <main className="flex flex-col gap-8 md:gap-12 px-4 md:px-10 py-6 md:py-10">
-        <section className="grid grid-cols-1 lg:grid-cols-3 gap-6 max-w-7xl mx-auto w-full">
+        <section className="grid grid-cols-1 lg:grid-cols-3 gap-6 mx-auto w-full">
           <Card className="col-span-1 flex flex-col">
             <div className="text-sm uppercase tracking-wide text-neutral-400 mb-1 font-semibold">
               Stretch goals
@@ -93,7 +93,7 @@ export default function Page() {
           </Card>
         </section>
 
-        <section className="max-w-7xl mx-auto w-full">
+        <section className="mx-auto w-full">
           <Card className="w-full">
             <SilentAuction auctions={data.auctions} bids={data.bids} />
           </Card>


### PR DESCRIPTION
makes more space for the stretch goals

before:

<img width="1626" height="1125" alt="image" src="https://github.com/user-attachments/assets/9b760381-b2c8-490c-b2cd-a7acd27e3f54" />

after:

<img width="1626" height="1125" alt="image" src="https://github.com/user-attachments/assets/8c860daa-e1dc-47f3-8cd0-2f6f60d7faf0" />
